### PR TITLE
[update]キャラ挙動の改善、滞空時間の調整

### DIFF
--- a/Scenes/InGame.unity
+++ b/Scenes/InGame.unity
@@ -279,7 +279,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 251081570}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 108.7, y: 6.56, z: -0.096746}
+  m_LocalPosition: {x: 108.7, y: -65.4, z: -0.096746}
   m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 0}
@@ -297,7 +297,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8f8c50bc3a5e6c941b3e51407f699e7e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  al: {fileID: 0}
 --- !u!1 &429837357
 GameObject:
   m_ObjectHideFlags: 0
@@ -662,7 +661,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -105.4
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalPosition.y
@@ -674,7 +673,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.x
@@ -682,7 +681,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.z
@@ -694,7 +693,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -796,9 +795,9 @@ NavMeshAgent:
   m_AgentTypeID: 0
   m_Radius: 0.5
   m_Speed: 3.5
-  m_Acceleration: 90
+  m_Acceleration: 360
   avoidancePriority: 50
-  m_AngularSpeed: 5
+  m_AngularSpeed: 120
   m_StoppingDistance: 0
   m_AutoTraverseOffMeshLink: 1
   m_AutoBraking: 1
@@ -959,7 +958,7 @@ MonoBehaviour:
   userObj: []
   nowShotUser: 0
   tag: 
-  randingPoint: {fileID: 0}
+  randingPoint: {fileID: 2116336691}
 --- !u!54 &1172014079
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1008,7 +1007,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8f8c50bc3a5e6c941b3e51407f699e7e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  al: {fileID: 0}
 --- !u!65 &1188467431
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1079,7 +1077,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1188467429}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 108.7, y: 6.56, z: -0.096746}
+  m_LocalPosition: {x: 108.7, y: -54.2, z: -0.096746}
   m_LocalScale: {x: 15, y: 10, z: 15}
   m_Children: []
   m_Father: {fileID: 0}
@@ -1181,7 +1179,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0df64818a7e009d478a351414a161a78, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 1172014077}
 --- !u!1001 &1666853045
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1355,6 +1352,101 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2116336691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2116336695}
+  - component: {fileID: 2116336694}
+  - component: {fileID: 2116336693}
+  - component: {fileID: 2116336692}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &2116336692
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2116336691}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2116336693
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2116336691}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2116336694
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2116336691}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2116336695
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2116336691}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -72, z: 0}
+  m_LocalScale: {x: 5, y: 1, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2122987217
 GameObject:

--- a/Scripts/AI.cs
+++ b/Scripts/AI.cs
@@ -25,7 +25,7 @@ public class AI : MonoBehaviour
     //理解はしてないけど3d空間上でのClick座標を取得するのに使う
     RaycastHit hit;
 
-    int a = 0;
+    int motionCnt = 0;
 
     void Start()
     {
@@ -36,8 +36,9 @@ public class AI : MonoBehaviour
     void Update()
     {
         float dis = Vector3.Distance(this.GetComponent<NavMeshAgent>().transform.position, ball.transform.position);
-
-        if (ball.Tag == "Player" && dis >= 10)
+        
+        //nowUserTag
+        if (ball.nowUserTag == "Player" && dis >= 10 && ball.transform.position.x<=-20)
         {
             //プレイヤーを走るモーションにする
             this.animator.SetBool("is_Run", true);
@@ -52,16 +53,12 @@ public class AI : MonoBehaviour
 
             racket.transform.position = new Vector3(player.position.x, player.position.y + 1, player.position.z);
 
-            //スイングAnimationにする予定
-            this.animator.SetBool("is_RightShake", true);
-
             //円の大きさを測る
             this.CharaStatus.CharaCircle = Base.CircleScale();
 
             //プレイヤー状態を振るに変更
             this.CharaStatus.RacketSwing = 2;
         }
-
 
         //移動中かどうか
         if (Base.PositionJudge(player.position, nowPosition))
@@ -83,16 +80,19 @@ public class AI : MonoBehaviour
             this.CharaStatus.RacketSwing = 0;
         }
 
+        if(dis <=50)
+        {
+            this.animator.SetBool("is_RightShake", true);
+        }
+
         //振る状態時なら50カウント後に待機状態に戻す
         if (this.animator.GetBool("is_RightShake") == true)
         {
-            a++;
+            motionCnt++;
 
-            if (a > 50)
+            if (motionCnt > 50)
             {
-                a = 0;
-
-                racket.transform.position = new Vector3(0, -100, 0);
+                motionCnt = 0;
 
                 //プレイヤー状態を待機に変更
                 this.CharaStatus.RacketSwing = 0;
@@ -101,17 +101,21 @@ public class AI : MonoBehaviour
                 this.animator.SetBool("is_RightShake", false);
             }
         }
-
+        //nowUserTag
         //振ったラケットが当たったら
-        if (ball.Tag == "Player" && dis <= 20)
+        //if文おかしいけど現状はこのままで
+        if (ball.nowUserTag == "Player" && dis <= 10)
         {
             //振る
             Base.Swing(CharaStatus.CharaPower);
+
+            racket.transform.position = new Vector3(0, -100, 0);
             judgement.HitFlg2 = false;
         }
 
+        //Debug.Log(judgement.HitFlg2);
+
         //現在の座標を取得
         nowPosition = player.position;
-
     }
 }

--- a/Scripts/Base.cs
+++ b/Scripts/Base.cs
@@ -141,10 +141,10 @@ public class Base : MonoBehaviour
 
         //この二つ変数をProjectileMotion関数に渡す
 
-        //とりあえず最低5秒滞空時間があるとしてます　(8～10秒)
-        flightTime = (float)Shot.GetTapTime / 120 * 4 + 10;
-            //とりあえず6で割ってます数値的には1.6666666
-            speed = (float)_power / 6;
+        //とりあえず最低5秒滞空時間があるとしてます　(5～12秒)
+        flightTime = (float)Shot.GetTapTime / 12 + 4;
+            //とりあえず7で割ってます数値的には1.42
+            speed = (float)_power / 7;
 
             flg = true;
     }

--- a/Scripts/Judgement.cs
+++ b/Scripts/Judgement.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 
 public class Judgement : MonoBehaviour
 {
-    [SerializeField] AI al;
     //ラケットが当たったフラグ
     private bool hitFlg = false;
     //ラケットが当たったフラグ


### PR DESCRIPTION
## 概要

キャラ挙動の改善、滞空時間の調整

## 技術的変更点概要

プレイヤークリック時そのクリック場所が相手コート側なら移動しない
AIも同様
滞空時間のパラメータの調整

## 今回保留した項目とTODOリスト

motion関連、パラメータ微調整など

## その他

もしかしてAIが打ち返すときその前にプレイヤーが入力した長さ(長押し時間と線の長さ)がそのまま入ってる感じですかね
