### PR TITLE
[update]サーブフラグとサーブ時の移動制限の追加

### DIFF
--- a/Scenes/InGame.unity
+++ b/Scenes/InGame.unity
@@ -497,6 +497,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 605d56812e2812c4db76a4da1e9cf0d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameManager: {fileID: 487528676}
   ball: {fileID: 0}
 --- !u!4 &521944218
 Transform:
@@ -1148,7 +1149,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -81
+      value: -77.3
       objectReference: {fileID: 0}
     - target: {fileID: 400328, guid: 49f2055d53eeb4e5a92af590a44bddee, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1401,6 +1402,7 @@ MonoBehaviour:
   ball: {fileID: 1172014078}
   pointB: {fileID: 2076708612}
   score: {fileID: 2132639381}
+  gameManager: {fileID: 487528676}
 --- !u!65 &1834506132
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Scripts/Base.cs
+++ b/Scripts/Base.cs
@@ -6,7 +6,7 @@ using UnityEngine.AI;
 
 public class Base : MonoBehaviour
 {
-
+    [SerializeField] GameManager gameManager;
     [SerializeField] Ball ball;
 
 
@@ -157,6 +157,13 @@ public class Base : MonoBehaviour
     //共通処理　スイング
     public void Swing(double _power, double _flight, double _taptime)
     {
+        //サーブフラグをオフに
+        if(gameManager.isServe == true)
+        {
+            gameManager.isServe = false;
+        }
+
+
         //滞空時間　タップ時間から　
         //速度　　　パワーから
 

--- a/Scripts/Base.cs
+++ b/Scripts/Base.cs
@@ -6,7 +6,6 @@ using UnityEngine.AI;
 
 public class Base : MonoBehaviour
 {
-    [SerializeField] GameManager gameManager;
     [SerializeField] Ball ball;
 
 
@@ -158,9 +157,9 @@ public class Base : MonoBehaviour
     public void Swing(double _power, double _flight, double _taptime)
     {
         //サーブフラグをオフに
-        if(gameManager.isServe == true)
+        if(GameManager.instance.isServe == true)
         {
-            gameManager.isServe = false;
+            GameManager.instance.isServe = false;
         }
 
 

--- a/Scripts/CharacterMove.cs
+++ b/Scripts/CharacterMove.cs
@@ -16,6 +16,7 @@ public class CharacterMove : MonoBehaviour
     [SerializeField] Ball ball;
     [SerializeField] GameObject pointB;
     [SerializeField] Score score;
+    [SerializeField] GameManager gameManager;
     //前の座標と今の座標を比べるために使う変数
     Vector3 nowPosition;
 
@@ -158,35 +159,57 @@ public class CharacterMove : MonoBehaviour
 
     void TapMove()
     {
-        //クリック
-        if (Base.touch_state._touch_flag == true && Base.touch_state._touch_phase == TouchPhase.Ended)
+        //サーブフラグがtrueならしない
+        if(gameManager.isServe !=true)
         {
-            //現状の移動指定地を削除
-            GetComponent<NavMeshAgent>().ResetPath();
-
-            //クリック時間によって処理を分ける
-            if (Shot.GetTapTime <= 10)
+            //クリック
+            if (Base.touch_state._touch_flag == true && Base.touch_state._touch_phase == TouchPhase.Ended)
             {
-                //移動の処理
-                Vector3 xyz = Base.Move(Input.mousePosition, hit);
+                //現状の移動指定地を削除
+                GetComponent<NavMeshAgent>().ResetPath();
 
-                //ネット越えないように
-                if (xyz.x >= 20)
+                //クリック時間によって処理を分ける
+                if (Shot.GetTapTime <= 10)
                 {
-                    GetComponent<NavMeshAgent>().destination = Base.Move(Input.mousePosition, hit);
+                    //移動の処理
+                    Vector3 xyz = Base.Move(Input.mousePosition, hit);
+
+                    //ネット越えないように
+                    if (xyz.x >= 20)
+                    {
+                        GetComponent<NavMeshAgent>().destination = Base.Move(Input.mousePosition, hit);
+                    }
+                }
+                //長押し
+                else
+                {
+                    //スイングAnimationにする予定
+                    animator.SetBool("is_RightShake", true);
+
+                    //円の大きさを測る
+                    CharaStatus.CharaCircle = Base.CircleScale(Shot.GetDistance);
+
+                    //プレイヤー状態を振るに変更
+                    CharaStatus.NowState = 2;
                 }
             }
-            //長押し
-            else
+        }
+        //横移動のみ
+        else
+        {
+            //クリック
+            if (Base.touch_state._touch_flag == true && Base.touch_state._touch_phase == TouchPhase.Ended)
             {
-                //スイングAnimationにする予定
-                animator.SetBool("is_RightShake", true);
+                //クリック時間によって処理を分ける
+                if (Shot.GetTapTime <= 10)
+                {
+                    //移動の処理
+                    Vector3 xyz = Base.Move(Input.mousePosition, hit);
 
-                //円の大きさを測る
-                CharaStatus.CharaCircle = Base.CircleScale(Shot.GetDistance);
+                    xyz.x = 125;
 
-                //プレイヤー状態を振るに変更
-                CharaStatus.NowState = 2;
+                    GetComponent<NavMeshAgent>().destination = xyz;          
+                }
             }
         }
     }

--- a/Scripts/CharacterMove.cs
+++ b/Scripts/CharacterMove.cs
@@ -16,7 +16,6 @@ public class CharacterMove : MonoBehaviour
     [SerializeField] Ball ball;
     [SerializeField] GameObject pointB;
     [SerializeField] Score score;
-    [SerializeField] GameManager gameManager;
     //前の座標と今の座標を比べるために使う変数
     Vector3 nowPosition;
 
@@ -160,7 +159,7 @@ public class CharacterMove : MonoBehaviour
     void TapMove()
     {
         //サーブフラグがtrueならしない
-        if(gameManager.isServe !=true)
+        if(GameManager.instance.isServe!= true)
         {
             //クリック
             if (Base.touch_state._touch_flag == true && Base.touch_state._touch_phase == TouchPhase.Ended)


### PR DESCRIPTION
## 概要

サーブ時の処理の追加

## 技術的変更点概要

サーブフラグがオンでスイング成功時ゲームマネージャーのサーブフラグをオフに
サーブ時にX方向(前方)には動かないように制限をかけました

## 今回保留した項目とTODOリスト

ショット時の処理の修正

## その他

しめしめ